### PR TITLE
Fix spacing for "Back to About" button on Past Board Members page

### DIFF
--- a/src/components/About/PastBoardMembers.jsx
+++ b/src/components/About/PastBoardMembers.jsx
@@ -40,7 +40,7 @@ const PastBoardMembers = () => {
   return (
     <div className="about-page page-transition">
       {/* Hero Section */}
-      <section className="hero-section">
+      <section className="hero-section past-board-hero">
         <div className="container">
           <h1 className="fade-in-up">Past Board Members</h1>
           <p className="fade-in-up">Meet the dedicated individuals who helped build and shape Black in Tech at UCI</p>

--- a/src/components/ClubPageExample.css
+++ b/src/components/ClubPageExample.css
@@ -111,6 +111,10 @@
   letter-spacing: 0.3px;
 }
 
+.past-board-hero p {
+  margin-bottom: 28px;
+}
+
 .container {
   width: 90%;
   max-width: 1200px;


### PR DESCRIPTION
## Summary
Adds vertical spacing between the hero subtitle text and the "Back to About" CTA button on the "Past Board Members" page to improve website readability on both desktop and mobile.

## Type of Change
- [ ] Bug fix
- [X] Small UI fix
- [ ] Cleanup / refactor
- [ ] Docs update

## Routes / Pages Changed
- Past Board Members page(PastBoardMembers.jsx)
- Hero Section styles(ClubPageExample.css)

## Screenshots
Desktop - Before UI Fix: 
<img width="1900" height="431" alt="Screenshot 2026-01-12 115032" src="https://github.com/user-attachments/assets/74e6f397-b383-46e4-a2fb-7886d0c7f2fd" />

Desktop - After UI Fix:
<img width="1903" height="463" alt="Screenshot 2026-01-12 115051" src="https://github.com/user-attachments/assets/2fa08713-9740-4c9d-af78-d57755cfa39d" />

Mobile (390px) - Before UI Fix:
<img width="487" height="571" alt="Screenshot 2026-01-12 115406" src="https://github.com/user-attachments/assets/11965276-fa9d-473f-a35d-19bbf859bcff" />

Mobile (390px) - After UI Fix:
<img width="487" height="597" alt="Screenshot 2026-01-12 115418" src="https://github.com/user-attachments/assets/ebdc2316-0093-454f-909d-4c274984a26b" />

## Testing Checklist
- [X] `npm run dev` runs without errors
- [X] Routes affected are verified
- [X] Mobile layout checked
- [X] No new console errors
- [X] Images load correctly (no 404s in Network tab)

## Reviewer Notes
This change/fix is specific to the Past Board Members hero section by using a page-specific class. No other hero sections or CTA buttons across the website are affected. Verified spacing at both desktop width and 390px mobile view.