### PR TITLE
Fix Dropdown Menu Showing on Middle of Screen

### DIFF
--- a/src/components/Layout/Layout.css
+++ b/src/components/Layout/Layout.css
@@ -95,6 +95,7 @@
 @media (max-width: 768px) {
   .header {
     padding: 15px 20px;
+    position: relative;
   }
 
   .mobile-menu-button {


### PR DESCRIPTION
## Summary
Make header positioning relative, so that the drop down menu is relative to that instead of the viewport.

## Task Completion
Fix on any page when the screen width is minimal, clicking the hamburger menu button opens the menu to direct to different pages in the middle of the screen.

## Type of Change
- [ ] Bug fix
- [x] Small UI fix
- [ ] Cleanup / refactor
- [ ] Docs update

## Routes / Pages Changed
Home

## Screenshots
Desktop: N/A
Mobile (~390px): 
<img width="443" height="445" alt="Screenshot 2026-01-22 at 11 26 20 AM" src="https://github.com/user-attachments/assets/5405f136-ecdb-42a1-b707-1e7bb33cd42c" />

## Testing Checklist
- [x] `npm run dev` runs without errors
- [x] Routes affected are verified
- [x] Mobile layout checked
- [x] No new console errors
- [x] Images load correctly (no 404s in Network tab)

## Reviewer Notes
N/A