### PR TITLE
Fix Home mobile hero cutoff + responsive text

### DIFF
--- a/src/components/Home/Home.css
+++ b/src/components/Home/Home.css
@@ -580,6 +580,24 @@ html, body {
   }
 }
 
+@media (max-width: 390px) {
+  .hero {
+    padding: 30px 20px 70px;
+  }
+  
+  .hero-content h1 {
+    font-size: 1.5rem;
+  }
+  
+  .hero-content p {
+    font-size: 0.9rem;
+  }
+  
+  .cta h1 {
+    font-size: 1.2rem;
+  }
+}
+
 /* Page Transition Animation */
 @keyframes fadeInLeft {
   from {

--- a/src/components/Home/Home.css
+++ b/src/components/Home/Home.css
@@ -71,6 +71,11 @@ html, body {
   transition: transform 0.3s ease;
 }
 
+.logo {
+  width: 100%;
+  max-width: 100px;
+}
+
 .hero-content .logo:hover {
   transform: scale(1.05);
 }


### PR DESCRIPTION
Before:
<img width="484" height="878" alt="BiTHomeBefore" src="https://github.com/user-attachments/assets/97907e0e-e77b-40b0-bc27-06d079e7bbcf" />
After:
<img width="484" height="881" alt="BiTHomeAfter" src="https://github.com/user-attachments/assets/9e737ceb-6ad5-4651-b7b6-aebe70a84cca" />


Fixed text and image resizing on home screen such that it does not unnecessarily overflow or cut off.

*Note that Before and After screenshots were taken at 389px instead of 390px because even though the max-width parameter is set to 390px for the text resizing, the device toolbar only displayed the resized text at 389px and below.