### PR TITLE
Fix Mobile Spacing and Sizing for Category Filter Buttons on Resources Page

### DIFF
--- a/src/components/Resources/Resources.css
+++ b/src/components/Resources/Resources.css
@@ -309,11 +309,22 @@
   
   .resources-hero {
     padding: 70px 20px 60px;
+    margin-bottom: 2rem;
   }
   
   .resources-container {
-    margin-top: -30px;
+    margin-top: 0;
   }
+  
+  .category-tab {
+    padding: 0.75rem 1.125rem;
+    font-size: 1rem;
+  }
+
+  .resource-categories {
+    gap: 0.75rem;
+  }
+  
 }
 
 /* Modern styling for resource cards if they exist */


### PR DESCRIPTION
**Summary**
Improves the mobile layout on the Resources page by increasing vertical spacing between the hero section and the category filter buttons, and increasing the size of the category buttons for better readability and tap targets. Removes a negative margin that was causing the content to appear too close together on mobile view.

**Type of Change**
- [ ] Bug Fix
- [X] Small UI fix
- [ ] Cleanup / refactor
- [ ] Docs update

**Routes/Pages Changed**

- /resources(Resources Page, Resources.css)

**Screenshots**

Mobile(390px):

Before:
<img width="407" height="550" alt="Screenshot 2026-01-26 003316" src="https://github.com/user-attachments/assets/e06e6a19-9663-4c3f-883a-dc6400fc1618" />

After:
<img width="387" height="517" alt="Screenshot 2026-01-26 003502" src="https://github.com/user-attachments/assets/1ca375ac-e112-4be6-952b-9686b3ce358b" />

**Testing Checklist**
- [X] npm run dev runs without errors
- [X] Routes affected are verified
- [X]  Mobile layout checked
- [X]  No new console errors
- [X]  Images load correctly (no 404s in Network tab)

**Reviewer Notes**
- Removed the negative top margin on the resources container that was pulling the category buttons too close to the hero section on mobile.
- Increased the category filter button padding and font size using `rem` units to improve tap target size and accessibility.
- The changes are scoped to mobile via media queries and do not affect the desktop layout.

