### PR TITLE
Revert "Fix Home mobile hero cutoff + responsive text"

### DIFF
--- a/src/components/Home/Home.css
+++ b/src/components/Home/Home.css
@@ -70,11 +70,6 @@ html, body {
   transition: transform 0.3s ease;
 }
 
-.logo {
-  width: 100%;
-  max-width: 100px;
-}
-
 .hero-content .logo:hover {
   transform: scale(1.05);
 }
@@ -576,24 +571,6 @@ html, body {
   
   .cta h1 {
     font-size: 1.8rem;
-  }
-}
-
-@media (max-width: 390px) {
-  .hero {
-    padding: 30px 20px 70px;
-  }
-  
-  .hero-content h1 {
-    font-size: 1.5rem;
-  }
-  
-  .hero-content p {
-    font-size: 0.9rem;
-  }
-  
-  .cta h1 {
-    font-size: 1.2rem;
   }
 }
 


### PR DESCRIPTION
## Summary
Undoes merge PR #17 

This PR request reverts the repo back to its main branch where it merged with PR #15 to revert logo changes.

## Type of Change
- [ ] Bug fix
- [X] Small UI fix
- [ ] Cleanup / refactor
- [ ] Docs update

## Routes / Pages Changed
Home

## Screenshots
Desktop:

<img width="1440" height="724" alt="image" src="https://github.com/user-attachments/assets/13684fda-5cb5-4678-8c0d-792de4be59e4" />


Mobile (~390px): 

<img width="291" height="627" alt="image" src="https://github.com/user-attachments/assets/5ee226b7-a8dc-4ed7-a893-9d1ced8a0099" />


## Testing Checklist
- [X] `npm run dev` runs without errors
- [X] Routes affected are verified
- [X] Mobile layout checked
- [X] No new console errors
- [X] Images load correctly (no 404s in Network tab)

## Reviewer Notes
Refer to comment on PR #17. 