### PR TITLE
Added fadeInUp to page

### DIFF
--- a/src/components/GetInvolved/GetInvolved.css
+++ b/src/components/GetInvolved/GetInvolved.css
@@ -484,6 +484,10 @@ section {
   }
 }
 
+.page-transition {
+  animation: fadeInUp 1s ease-out;
+}
+
 .fade-in-up {
   animation: fadeInUp 1s ease-out;
 }

--- a/src/components/GetInvolved/GetInvolved.jsx
+++ b/src/components/GetInvolved/GetInvolved.jsx
@@ -12,7 +12,7 @@ const GetInvolved = () => {
   };
 
   return (
-    <div className="get-involved-page">
+    <div className="get-involved-page page-transition">
       {/* Hero Section with Modern Design */}
       <div className="hero-section">
         <div className="container">


### PR DESCRIPTION
## Summary
Addresses #9 , where the get involved page had page transition animation.

## Task Completion
Make the get involved page have the same animation as the other pages.
 
## Type of Change
- [ ] Bug fix
- [x] Small UI fix
- [ ] Cleanup / refactor
- [ ] Docs update

## Routes / Pages Changed
`/get-involved`

## Screenshots
Desktop:

https://github.com/user-attachments/assets/826df64c-4e0d-45a0-a6fd-5e6f07f6ef3b

Mobile (~390px): 

https://github.com/user-attachments/assets/d363705b-6e05-4db4-a734-956d50cf183f


## Testing Checklist
- [x] `npm run dev` runs without errors
- [x] Routes affected are verified
- [x] Mobile layout checked
- [x] No new console errors
- [x] Images load correctly (no 404s in Network tab)

## Reviewer Notes
N/A. For user experience on mobile, does it make sense to hide the menu after the user clicks a link?