### PR TITLE
Added responsive text resizing for 390px

### DIFF
--- a/src/components/Home/Home.css
+++ b/src/components/Home/Home.css
@@ -574,6 +574,24 @@ html, body {
   }
 }
 
+@media (max-width: 390px) {
+  .hero {
+    padding: 30px 20px 70px;
+  }
+  
+  .hero-content h1 {
+    font-size: 1.5rem;
+  }
+  
+  .hero-content p {
+    font-size: 0.9rem;
+  }
+  
+  .cta h1 {
+    font-size: 1.2rem;
+  }
+}
+
 /* Page Transition Animation */
 @keyframes fadeInLeft {
   from {


### PR DESCRIPTION
Added functionality such that the home subheading text is resized for screen widths under 390px.
This addresses the issues aimed to be fixed under PR #17 through re-adding the responsive text but not touching the resizing of the Black in Tech Logo as that is already fixed.

Before:
<img width="459" height="676" alt="BiTResizeBefore" src="https://github.com/user-attachments/assets/90fadd94-4435-4dbe-9f67-c47e66ee7eee" />

After:
<img width="460" height="666" alt="BiTResizeAfter" src="https://github.com/user-attachments/assets/a42f96d7-f167-4021-9cae-9129025d2559" />
