### PR TITLE
Updated and Organized Past Board Members Page

### DIFF
--- a/src/components/About/PastBoardMembers.jsx
+++ b/src/components/About/PastBoardMembers.jsx
@@ -34,11 +34,6 @@ const PastBoardMembers = () => {
           image: '/images/BoardSolo/Stephanie Onwu.jpg',
         },
         {
-          name: "Angela Wang",
-          position: "Marketing",
-          image: '/images/BoardSolo/Angela Wang.jpg',
-        },
-        {
           name: "Brina White",
           position: "Marketing",
           image: '/images/BoardSolo/Brina White.jpg',
@@ -84,6 +79,11 @@ const PastBoardMembers = () => {
           image: '/images/BoardSolo/JasonSolo.jpg',
         },
         {
+          name: "Steven Gorlicki",
+          position: "Web Developer",
+          image: '/images/BoardSolo/StevenSolo.jpg',
+        },
+        {
           name: "Ijeoma Arisa",
           position: "Corporate Outreach",
           image: '/images/BoardSolo/IjeomaSolo.jpg',
@@ -117,21 +117,26 @@ const PastBoardMembers = () => {
       <section className="board-section">
         <div className="container">
           <h2 className="fade-in-up">Our Past Board Members</h2>
-          <div className="board-members">
-            {pastBoardMembers.map((member, index) => (
-              <div className="board-member scale-in" key={index}>
-                <div className="member-image">
-                  <img 
-                    src={member.image} 
-                    alt={member.name} 
-                    onError={(e) => PlaceholderImage.handleImageError(e, member.name)}
-                  />
-                </div>
-                <h3>{member.name}</h3>
-                <p className="position">{member.position}</p>
+          {pastBoardMembersByYear.map((group) => (
+            <div className="past-board-year-group" key={group.year}>
+              <h3 className="past-board-year-heading">{group.year}</h3>
+              <div className="board-members">
+                {group.members.map((member, index) => (
+                  <div className="board-member scale-in" key={`${group.year}-${index}`}>
+                    <div className="member-image">
+                      <img
+                        src={member.image} 
+                        alt={member.name} 
+                        onError={(e) => PlaceholderImage.handleImageError(e, member.name)}
+                      />
+                    </div>
+                    <h3>{member.name}</h3>
+                    <p className="position">{member.position}</p>
+                  </div>
+                ))}
               </div>
-            ))}
-          </div>
+            </div>
+          ))}
         </div>
       </section>
 

--- a/src/components/About/PastBoardMembers.jsx
+++ b/src/components/About/PastBoardMembers.jsx
@@ -4,31 +4,101 @@ import '../ClubPageExample.css';
 import PlaceholderImage from '../PlaceholderImage';
 
 const PastBoardMembers = () => {
-  const pastBoardMembers = [
+  const pastBoardMembersByYear = [
     {
-      name: "Jason Phan",
-      position: "Web Developer",
-      image: '/images/BoardSolo/JasonSolo.jpg',
+      year: "2025-2026",
+      members: [
+        {
+          name: "Chidera Okoroama",
+          position: "President",
+          image: '/images/BoardSolo/Chidera Okoroama.jpg',
+        },
+        {
+          name: "Chibueze Ndukwe",
+          position: "Vice President",
+          image: '/images/BoardSolo/Chibueze Ndukwe.jpg',
+        },
+        {
+          name: "Aurelia Aubrey",
+          position: "Treasurer",
+          image: '/images/BoardSolo/Aurelia Aubrey.jpg',
+        },
+        {
+          name: "Ziyad Abbas",
+          position: "Treasurer",
+          image: '/images/BoardSolo/Ziyad Abbas.jpg',
+        },
+        {
+          name: "Stephanie Onwu",
+          position: "Secretary",
+          image: '/images/BoardSolo/Stephanie Onwu.jpg',
+        },
+        {
+          name: "Angela Wang",
+          position: "Marketing",
+          image: '/images/BoardSolo/Angela Wang.jpg',
+        },
+        {
+          name: "Brina White",
+          position: "Marketing",
+          image: '/images/BoardSolo/Brina White.jpg',
+        },
+        {
+          name: "Juan Muhirwe",
+          position: "Event Coordinator",
+          image: '/images/BoardSolo/Juan Muhirwe.jpg',
+        },
+        {
+          name: "Mahanth Kommireddy",
+          position: "Event Coordinator",
+          image: '/images/BoardSolo/Mahanth Kommireddy.jpg',
+        },
+        {
+          name: "Nahum Gebreab",
+          position: "Internal Outreach",
+          image: '/images/BoardSolo/Nahum Gebreab.jpg',
+        },
+        {
+          name: "Derrick Thrower",
+          position: "Web Developer",
+          image: '/images/BoardSolo/Derrick Thrower.jpg',
+        },
+        {
+          name: "Ival Momoh",
+          position: "Web Developer",
+          image: '/images/BoardSolo/Ival Momoh.jpg',
+        },
+        {
+          name: "Chioma Madu",
+          position: "General Officer",
+          image: '/images/BoardSolo/Chioma Madu.jpg',
+        }
+      ]
     },
     {
-      name: "Steven Gorlicki",
-      position: "Web Developer",
-      image: '/images/BoardSolo/StevenSolo.jpg',
-    },
-    {
-      name: "Ijeoma Arisa",
-      position: "Corporate Outreach",
-      image: '/images/BoardSolo/IjeomaSolo.jpg',
-    },
-    {
-      name: "Daniel Gonzales",
-      position: "Marketing",
-      image: '/images/BoardSolo/DanielSolo.jpg',
-    },
-    {
-      name: "Kaneto Ejizu",
-      position: "Co-Event Chair",
-      image: '/images/BoardSolo/KanetoSolo.jpg',
+      year: "2024-2025",
+      members: [
+        {
+          name: "Jason Phan",
+          position: "Web Developer",
+          image: '/images/BoardSolo/JasonSolo.jpg',
+        },
+        {
+          name: "Ijeoma Arisa",
+          position: "Corporate Outreach",
+          image: '/images/BoardSolo/IjeomaSolo.jpg',
+        },
+        {
+          name: "Daniel Gonzales",
+          position: "Marketing",
+          image: '/images/BoardSolo/DanielSolo.jpg',
+        },
+        {
+          name: "Kaneto Ejizu",
+          position: "Co-Event Chair",
+          image: '/images/BoardSolo/KanetoSolo.jpg',
+        }
+      ]
     }
   ];
 

--- a/src/components/About/PastBoardMembers.jsx
+++ b/src/components/About/PastBoardMembers.jsx
@@ -9,31 +9,26 @@ const PastBoardMembers = () => {
       name: "Jason Phan",
       position: "Web Developer",
       image: '/images/BoardSolo/JasonSolo.jpg',
-      bio: "Junior Computer Science major passionate about web technologies and developing inclusive digital spaces that represent diverse backgrounds."
     },
     {
       name: "Steven Gorlicki",
       position: "Web Developer",
       image: '/images/BoardSolo/StevenSolo.jpg',
-      bio: "Junior Software Engineer with a focus on front-end development and creating engaging user experiences that celebrate diversity."
     },
     {
       name: "Ijeoma Arisa",
       position: "Corporate Outreach",
       image: '/images/BoardSolo/IjeomaSolo.jpg',
-      bio: "Senior Computer Science major with strong networking skills and a passion for connecting underrepresented students with industry opportunities."
     },
     {
       name: "Daniel Gonzales",
       position: "Marketing",
       image: '/images/BoardSolo/DanielSolo.jpg',
-      bio: "Senior Computer Science major with a passion for creating engaging content and building community through strategic marketing initiatives."
     },
     {
       name: "Kaneto Ejizu",
       position: "Co-Event Chair",
       image: '/images/BoardSolo/KanetoSolo.jpg',
-      bio: "Junior Software Engineer with a flair for event planning and creating engaging workshops that build technical skills and community connections."
     }
   ];
 
@@ -64,7 +59,6 @@ const PastBoardMembers = () => {
                 </div>
                 <h3>{member.name}</h3>
                 <p className="position">{member.position}</p>
-                <p className="bio">{member.bio}</p>
               </div>
             ))}
           </div>

--- a/src/components/ClubPageExample.css
+++ b/src/components/ClubPageExample.css
@@ -249,6 +249,18 @@
   border: none;
 }
 
+.past-board-year-heading {
+  margin-bottom: 2rem;
+}
+
+.past-board-year-group {
+  margin-top: 3rem;
+}
+
+.past-board-year-group:first-of-type {
+  margin-top: 1rem;
+}
+
 .board-actions {
   margin-top: 40px;
   text-align: center;


### PR DESCRIPTION
## Summary
This PR updates the Past Board Members Page(on the About page) by addding the club's board members from this past year(2025-2026) to the pastBoardMembersByYear list, reflecting the current, up-to-date list of past board members. 

Additionally, the pastBoardMembersByYear list is now organized into years, in order to group board members based on the years they served on board(ex. 2025-2026 and 2024-2025). 

Lastly, this PR removes emmber bios as a data value from the list, keeping each board member "card" on the website to just include only the following information: name, position, and image.

## Task Completion
Issue #25 

## Type of Change
- [ ] Bug fix
- [X] Small UI fix
- [X] Cleanup / refactor
- [x] Docs update

## Routes / Pages Changed
- src/components/About/PastBoardMembers.jsx
- src/components/ClubPageExample.css

## Screenshots
Desktop:
<img width="1906" height="715" alt="image" src="https://github.com/user-attachments/assets/3e7d98fa-e534-4960-ab86-cdf50e978b9a" />

<img width="1574" height="959" alt="image" src="https://github.com/user-attachments/assets/2cbd917e-9878-429f-bd9b-b47604a396d5" />

<img width="1911" height="986" alt="image" src="https://github.com/user-attachments/assets/f8e48a4c-a1e8-49ce-bf28-da9ef457884d" />


Mobile (~390px): 
<img width="282" height="481" alt="image" src="https://github.com/user-attachments/assets/bd762139-b08e-42ea-a53b-fadea7f0ae92" />

<img width="269" height="554" alt="image" src="https://github.com/user-attachments/assets/3be2af59-019e-4cca-9306-d8f03b7abc27" />

<img width="253" height="563" alt="image" src="https://github.com/user-attachments/assets/b9ec85c9-4cb6-4a68-9f2f-4fa124d0f230" />

<img width="278" height="338" alt="image" src="https://github.com/user-attachments/assets/e4dbc0c1-e53a-4f8b-bd62-2113a25db51e" />

<img width="262" height="555" alt="image" src="https://github.com/user-attachments/assets/ce94377d-ee4f-48f9-9545-7245940fdeba" />

<img width="269" height="566" alt="image" src="https://github.com/user-attachments/assets/d4f45d27-55fd-4da0-bf12-c7f04d5aae46" />

## Testing Checklist
- [x] `npm run dev` runs without errors
- [X] Routes affected are verified
- [X] Mobile layout checked
- [X] No new console errors
- [X] Images load correctly (no 404s in Network tab)

## Reviewer Notes
N/A