### PR TITLE
Updated footer to accurately reflect current BiT website developers

### DIFF
--- a/src/components/Layout/Footer.jsx
+++ b/src/components/Layout/Footer.jsx
@@ -42,7 +42,7 @@ const Footer = () => {
         
         <div className="footer-bottom fade-in-up">
           <p>&copy; {new Date().getFullYear()} Black in Tech at UCI. All rights reserved.</p>
-          <p>Developed by Alyas Thomas, Steven Gorlicki, and Jason Phan</p>
+          <p>Developed by the BiT Web Development Team</p>
         </div>
       </div>
     </footer>


### PR DESCRIPTION
## Summary
This PR updates the website's footer to accurately represent who is currently developing the website. It closes #24

## Task Completion
Issue #24 

## Type of Change
- [ ] Bug fix
- [x] Small UI fix
- [ ] Cleanup / refactor
- [ ] Docs update

## Routes / Pages Changed
Footer

## Screenshots
Desktop: 
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/ca1e8037-9f2a-4de2-9858-c5f2a0735d4c" />

Mobile (~390px): 
<img width="390" height="700" alt="Screen Shot 2026-04-05 at 23 12 22" src="https://github.com/user-attachments/assets/db75e465-d2c5-4f5a-9744-dfec2f06acc0" />


## Testing Checklist
- [x] `npm run dev` runs without errors
- [x] Routes affected are verified
- [x] Mobile layout checked
- [x] No new console errors
- [x] Images load correctly (no 404s in Network tab)

## Reviewer Notes
N/A