### PR TITLE
Removed arrow Icon for cta buttons

### DIFF
--- a/src/components/Events/Events.css
+++ b/src/components/Events/Events.css
@@ -380,23 +380,6 @@ hr {
   box-shadow: 0 8px 15px rgba(0,0,0,0.15);
 }
 
-.cta-button::after {
-  content: "\f054"; /* Font Awesome chevron-right icon */
-  font-family: "Font Awesome 5 Free", FontAwesome, sans-serif;
-  font-weight: 900;
-  position: absolute;
-  top: 50%;
-  right: 20px;
-  transform: translateY(-50%);
-  opacity: 0;
-  transition: all 0.2s ease;
-}
-
-.cta-button:hover::after {
-  opacity: 1;
-  right: 15px;
-}
-
 /* Content Section */
 .events-content {
   max-width: 1400px;


### PR DESCRIPTION
## Summary
This change ensures that hovering over cta-buttons only shows the expect animation, without the flashing arrow.

## Task Completion
This PR aims to fix the current cta-button arrow flashing issue.

## Type of Change
- [x] Bug fix
- [x] Small UI fix
- [ ] Cleanup / refactor
- [ ] Docs update

## Routes / Pages Changed
Events/Events.css

## Screenshots

https://github.com/user-attachments/assets/291f55e2-274f-453e-b840-7e97fd4c8b8f

## Testing Checklist
- [x] `npm run dev` runs without errors
- [x] Routes affected are verified
- [x] Mobile layout checked
- [x] No new console errors
- [x] Images load correctly (no 404s in Network tab)

## Reviewer Notes
I deleted the cta hover after code in the Events.css file, because it's content was simply the arrow, which was not needed.