### PR TITLE
Added Sponsors CRUD Endpoints

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -1,5 +1,5 @@
 from fastapi import FastAPI
-from app.routers import board_members
+from app.routers import board_members, sponsors
 
 app = FastAPI(
     title="BIT UCI API",
@@ -30,3 +30,4 @@ def custom_openapi():
 app.openapi = custom_openapi
 
 app.include_router(board_members.router)
+app.include_router(sponsors.router)

--- a/app/routers/sponsors.py
+++ b/app/routers/sponsors.py
@@ -12,8 +12,8 @@ router = APIRouter(prefix="/sponsors", tags=["Sponsors"])
 @router.get("/get-all-sponsors", response_model = List[SponsorOut])
 def get_all_sponsors():
     # Fetch all data from the supabase sponsors table
-    sponsors_api_response = supabase.table("sponsors").select("*").execute()
-    return sponsors_api_response.data
+    get_all_sponsors_api_response = supabase.table("sponsors").select("*").execute()
+    return get_all_sponsors_api_response.data
 
 
 # Get A Specific Sponsor - PUBLIC request(no auth needed)
@@ -21,11 +21,18 @@ def get_all_sponsors():
 def get_a_sponsor(sponsor_id: str):
     # Fetch one particular row from the supabase sponsors table
     try:
-        sponsor_api_response = supabase.table("sponsors").select("*").eq("id", sponsor_id).single().execute()
-        return sponsor_api_response.data
+        get_sponsor_api_response = supabase.table("sponsors").select("*").eq("id", sponsor_id).single().execute()
+        return get_sponsor_api_response.data
     # Raises a 404 error to prevent a generic 500 Internal Server Error
     except Exception:
         raise HTTPException(status_code=404, detail="The sponsor you specified couldn't be found!")
 
+# Create A New Sponsor - PROTECTED request(auth needed)
+@router.post("/create-sponsor", response_model = SponsorOut, status_code = 201)
+def create_new_sponsor(new_sponsor: SponsorCreate, user = Depends(require_auth)):
+    # Insert sponsor data into new row in Supabase table
+    create_sponsor_api_response = supabase_admin.table("sponsors").insert(new_sponsor.model_dump()).execute()
+    # Return the new row data
+    return create_sponsor_api_response.data[0]
 
 

--- a/app/routers/sponsors.py
+++ b/app/routers/sponsors.py
@@ -4,17 +4,28 @@ from app.schemas.sponsor import SponsorCreate, SponsorUpdate, SponsorOut
 from app.dependencies import require_auth, security
 from app.config import supabase, supabase_admin
 from typing import List
-
 # # Group all sponsors routes/endpoints together
 router = APIRouter(prefix="/sponsors", tags=["Sponsors"])
 
-# Get All - PUBLIC
+# Get All Sponsors - PUBLIC request(no auth needed)
 
 @router.get("/get-all-sponsors", response_model = List[SponsorOut])
 def get_all_sponsors():
     # Fetch all data from the supabase sponsors table
-    api_response = supabase.table("sponsors").select("*").execute()
-    return api_response.data
+    sponsors_api_response = supabase.table("sponsors").select("*").execute()
+    return sponsors_api_response.data
+
+
+# Get A Specific Sponsor - PUBLIC request(no auth needed)
+@router.get("/get-sponsor/{sponsor_id}", response_model = SponsorOut)
+def get_a_sponsor(sponsor_id: str):
+    # Fetch one particular row from the supabase sponsors table
+    try:
+        sponsor_api_response = supabase.table("sponsors").select("*").eq("id", sponsor_id).single().execute()
+        return sponsor_api_response.data
+    # Raises a 404 error to prevent a generic 500 Internal Server Error
+    except Exception:
+        raise HTTPException(status_code=404, detail="The sponsor you specified couldn't be found!")
 
 
 

--- a/app/routers/sponsors.py
+++ b/app/routers/sponsors.py
@@ -9,13 +9,11 @@ from typing import List
 router = APIRouter(prefix="/sponsors", tags=["Sponsors"])
 
 # Get All Sponsors - PUBLIC request(no auth needed)
-
 @router.get("/get-all-sponsors", response_model = List[SponsorOut])
 def get_all_sponsors():
     # Fetch all data from the supabase sponsors table
     get_all_sponsors_api_response = supabase.table("sponsors").select("*").execute()
     return get_all_sponsors_api_response.data
-
 
 # Get A Specific Sponsor - PUBLIC request(no auth needed)
 @router.get("/get-sponsor/{sponsor_id}", response_model = SponsorOut)
@@ -86,10 +84,12 @@ def update_existing_sponsor(sponsor_id: str, sponsor: SponsorUpdate, user = Depe
     # Update the specified sponsor row in the table with the changes that have been made
     response = supabase_admin.table("sponsors").update(updates).eq("id", sponsor_id).execute()
     if not response.data:
-        raise HTTPException(status_code=404, detail="Invalid sponsor id.")
+        raise HTTPException(status_code = 404, detail = "Couldn't find the sponsor you specified!")
     return response.data[0]
 
-
-
-
-
+# Delete An Existing Sponsor - PROTECTED Request(Auth Needed)
+@router.delete("/delete-sponsor/{sponsor_id}", status_code = 204)
+def delete_sponsor(sponsor_id: str, user = Depends(require_auth)):
+    delete_sponsor_response = supabase_admin.table("sponsors").delete().eq("id", sponsor_id).execute()
+    if not delete_sponsor_response.data:
+        raise HTTPException(status_code = 404, detail = "Couldn't find the sponsor you specified!")

--- a/app/routers/sponsors.py
+++ b/app/routers/sponsors.py
@@ -4,6 +4,7 @@ from app.schemas.sponsor import SponsorCreate, SponsorUpdate, SponsorOut
 from app.dependencies import require_auth, security
 from app.config import supabase, supabase_admin
 from typing import List
+
 # # Group all sponsors routes/endpoints together
 router = APIRouter(prefix="/sponsors", tags=["Sponsors"])
 
@@ -30,7 +31,7 @@ def get_a_sponsor(sponsor_id: str):
 # Create A New Sponsor - PROTECTED request(auth needed)
 @router.post("/create-sponsor", response_model = SponsorOut, status_code = 201)
 def create_new_sponsor(new_sponsor: SponsorCreate, user = Depends(require_auth)):
-
+    valid_sponsor_tiers = ["Gold", "Silver", "Bronze"]
     new_sponsor.name = new_sponsor.name.strip()
     # Verify that the sponsor name has actually been provided
     if new_sponsor.name == "":
@@ -42,9 +43,7 @@ def create_new_sponsor(new_sponsor: SponsorCreate, user = Depends(require_auth))
     # Checks to see if the duplicate sponsor name check returned data(invalid case)
     if existing_sponsor_response.data:
         raise HTTPException(status_code = 409, detail = "A sponsor with this name already exists.")
-    
     # Verfiy that if the user has provided a tier, it's a valid one
-    valid_sponsor_tiers = ["Gold", "Silver", "Bronze"]
     if new_sponsor.tier is not None:
         new_sponsor.tier = new_sponsor.tier.strip().capitalize()
         if new_sponsor.tier not in valid_sponsor_tiers:
@@ -53,3 +52,44 @@ def create_new_sponsor(new_sponsor: SponsorCreate, user = Depends(require_auth))
     create_sponsor_api_response = supabase_admin.table("sponsors").insert(new_sponsor.model_dump(mode="json")).execute()
     # Return the new row data
     return create_sponsor_api_response.data[0]
+
+# Update An Existing Sponsor - PROTECTED request(auth needed)
+@router.patch("/update-sponsor/{sponsor_id}", response_model = SponsorOut)
+def update_existing_sponsor(sponsor_id: str, sponsor: SponsorUpdate, user = Depends(require_auth)):
+
+    valid_sponsor_tiers = ["Gold", "Silver", "Bronze"]
+
+    # Make a dictionary consisting of the schema fields and associated values the user indicated they want to update
+    updates = {field: value for field, value in sponsor.model_dump(mode="json").items() if value is not None}
+    if not updates:
+        raise HTTPException(status_code = 400, detail = "There are no fields to update.")
+    
+    if "name" in updates:
+        updates["name"] = updates["name"].strip()
+        if updates["name"] == "":
+            raise HTTPException(status_code = 400, detail = "Sponsor name cannot be empty.")
+        
+        # Check to see if the sponsor name already exists in the database
+        existing_sponsor_response = (supabase.table("sponsors").select("id").ilike("name", updates["name"]).execute())
+        if existing_sponsor_response.data:
+
+            existing_sponsor_id = str(existing_sponsor_response.data[0]["id"])
+            # ONLY check for duplicate sponsors amongst OTHER rows in the table
+            if existing_sponsor_id != sponsor_id:
+                raise HTTPException(status_code = 409, detail = "A sponsor with this name already exists.")
+    
+    if "tier" in updates:
+        updates["tier"] = updates["tier"].strip().capitalize()
+        if updates["tier"] not in valid_sponsor_tiers:
+            raise HTTPException(status_code = 400, detail = "Sponsor tier must be Gold, Silver, or Bronze.")
+        
+    # Update the specified sponsor row in the table with the changes that have been made
+    response = supabase_admin.table("sponsors").update(updates).eq("id", sponsor_id).execute()
+    if not response.data:
+        raise HTTPException(status_code=404, detail="Invalid sponsor id.")
+    return response.data[0]
+
+
+
+
+

--- a/app/routers/sponsors.py
+++ b/app/routers/sponsors.py
@@ -1,0 +1,20 @@
+from fastapi import APIRouter, HTTPException, Depends
+from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
+from app.schemas.sponsor import SponsorCreate, SponsorUpdate, SponsorOut
+from app.dependencies import require_auth, security
+from app.config import supabase, supabase_admin
+from typing import List
+
+# # Group all sponsors routes/endpoints together
+router = APIRouter(prefix="/sponsors", tags=["Sponsors"])
+
+# Get All - PUBLIC
+
+@router.get("/get-all-sponsors", response_model = List[SponsorOut])
+def get_all_sponsors():
+    # Fetch all data from the supabase sponsors table
+    api_response = supabase.table("sponsors").select("*").execute()
+    return api_response.data
+
+
+

--- a/app/routers/sponsors.py
+++ b/app/routers/sponsors.py
@@ -30,9 +30,26 @@ def get_a_sponsor(sponsor_id: str):
 # Create A New Sponsor - PROTECTED request(auth needed)
 @router.post("/create-sponsor", response_model = SponsorOut, status_code = 201)
 def create_new_sponsor(new_sponsor: SponsorCreate, user = Depends(require_auth)):
-    # Insert sponsor data into new row in Supabase table
-    create_sponsor_api_response = supabase_admin.table("sponsors").insert(new_sponsor.model_dump()).execute()
+
+    new_sponsor.name = new_sponsor.name.strip()
+    # Verify that the sponsor name has actually been provided
+    if new_sponsor.name == "":
+        raise HTTPException(status_code = 400, detail = "Sponsor name cannot be empty.")
+    
+    # Verify that the sponsor isn't a duplicate entry in the database
+    existing_sponsor_response =  (supabase.table("sponsors").select("id").ilike("name", new_sponsor.name).execute())
+
+    # Checks to see if the duplicate sponsor name check returned data(invalid case)
+    if existing_sponsor_response.data:
+        raise HTTPException(status_code = 409, detail = "A sponsor with this name already exists.")
+    
+    # Verfiy that if the user has provided a tier, it's a valid one
+    valid_sponsor_tiers = ["Gold", "Silver", "Bronze"]
+    if new_sponsor.tier is not None:
+        new_sponsor.tier = new_sponsor.tier.strip().capitalize()
+        if new_sponsor.tier not in valid_sponsor_tiers:
+            raise HTTPException(status_code = 400, detail = "Sponsor tier must be Gold, Silver, or Bronze.")
+    # Insert sponsor data into a new row in the Supabase table
+    create_sponsor_api_response = supabase_admin.table("sponsors").insert(new_sponsor.model_dump(mode="json")).execute()
     # Return the new row data
     return create_sponsor_api_response.data[0]
-
-

--- a/app/schemas/sponsor.py
+++ b/app/schemas/sponsor.py
@@ -12,8 +12,8 @@ class SponsorCreate(BaseModel):
 
 class SponsorUpdate(BaseModel):
     name: Optional[str] = None
-    logo_url: Optional[str] = None
-    link: Optional[str] = None
+    logo_url: Optional[HttpUrl] = None
+    link: Optional[HttpUrl] = None
     tier: Optional[str] = None
 
 

--- a/app/schemas/sponsor.py
+++ b/app/schemas/sponsor.py
@@ -1,0 +1,22 @@
+from pydantic import BaseModel
+from typing import Optional
+import uuid
+
+
+class SponsorCreate(BaseModel):
+    name: str
+    logo_url: Optional[str] = None
+    link: Optional[str] = None
+    tier: Optional[str] = None
+
+
+class SponsorUpdate(BaseModel):
+    name: Optional[str] = None
+    logo_url: Optional[str] = None
+    link: Optional[str] = None
+    tier: Optional[str] = None
+
+
+
+class SponsorOut(SponsorCreate):
+    id: uuid.UUID

--- a/app/schemas/sponsor.py
+++ b/app/schemas/sponsor.py
@@ -5,9 +5,9 @@ import uuid
 
 class SponsorCreate(BaseModel):
     name: str
-    logo_url: Optional[str] = None
+    logo_url: str
     link: Optional[str] = None
-    tier: Optional[str] = None
+    tier: str
 
 
 class SponsorUpdate(BaseModel):

--- a/app/schemas/sponsor.py
+++ b/app/schemas/sponsor.py
@@ -1,13 +1,13 @@
-from pydantic import BaseModel
+from pydantic import BaseModel, HttpUrl
 from typing import Optional
 import uuid
 
 
 class SponsorCreate(BaseModel):
     name: str
-    logo_url: str
-    link: Optional[str] = None
-    tier: str
+    logo_url: HttpUrl
+    link: HttpUrl
+    tier: Optional[str] = None
 
 
 class SponsorUpdate(BaseModel):


### PR DESCRIPTION
## Summary
This PR creates CRUD endpoints for the Sponsors API.

Includes:
- Public GET all / GET one
- Auth-protected POST / PATCH / DELETE
- Input validation for sponsor creation and updates
- Tested in Swagger Docs (screenshots attached)

## Task Completion
Issue #35 

## Type of Change
- [ ] Bug fix
- [ ] Small UI fix
- [X] Cleanup / refactor
- [ ] Docs update

## Routes / Pages Changed
- routers/sponsors.py (created this page/file)
- schemas/sponsor.py (created this page/file)

## Screenshots
#1:  GET ALL  Sponsors Endpoint 

Screenshot of Pre-Existing Data in Sponsors Table In Supabase
<img width="1522" height="187" alt="image" src="https://github.com/user-attachments/assets/0eaa9574-7713-4005-aa7d-a00199d0e300" />

Screenshots of Using The Get All Sponsors Endpoint In Swagger Docs

<img width="1860" height="383" alt="image" src="https://github.com/user-attachments/assets/3396fcf2-7e47-422f-b67e-3c3fe7331415" />

<img width="1769" height="874" alt="image" src="https://github.com/user-attachments/assets/c2c213e1-25a5-4571-b3e6-0f045e54fbb8" />

<img width="1777" height="479" alt="image" src="https://github.com/user-attachments/assets/8219cad2-6685-4731-ad1b-93170049c598" />

#2: GET ONE Sponsors Endpoint

Screenshot of Specific Pre-Existing Row in Sponsors Table In Supabase(Will Use For This Demo)

<img width="1524" height="88" alt="image" src="https://github.com/user-attachments/assets/ac215048-8901-4b71-86d4-10b2161dd365" />

Screenshots of Using the Get One Sponsor Endpoint in Swagger Docs

<img width="1824" height="411" alt="image" src="https://github.com/user-attachments/assets/baa6f6f1-eca7-4b77-9e52-18c21906ebc6" />

<img width="1777" height="736" alt="image" src="https://github.com/user-attachments/assets/31e678ac-b769-4f44-8959-3a37ce2d7a0b" />

<img width="1776" height="876" alt="image" src="https://github.com/user-attachments/assets/6665f6fd-09e8-4c8d-beea-bb6f08e5680f" />

#3: POST/CREATE Sponsors Endpoint

Screenshot of Supabase Sponsors Table Before Creating A New Sponsor/Row Using The Endpoint

<img width="1538" height="185" alt="image" src="https://github.com/user-attachments/assets/d0af27d2-3260-4e17-9b0a-fd70a46a55c2" />

Screenshots of Using the POST/CREATE Sponsors Endpoint in Swagger Docs

<img width="1819" height="798" alt="image" src="https://github.com/user-attachments/assets/04dab0f4-f56d-4767-8d0d-ec5b11a1f33e" />

<img width="1767" height="864" alt="image" src="https://github.com/user-attachments/assets/a00a224c-05dc-4932-8010-c30392d0efac" />

<img width="1773" height="876" alt="image" src="https://github.com/user-attachments/assets/c1bd4aea-e886-4980-831e-cc6c4c34cb01" />

Screenshot Showing That the Sponsors Table In Supabase Has Now Been Updated With this New Sponsor(OpenAI)

<img width="1381" height="222" alt="image" src="https://github.com/user-attachments/assets/8ac24082-55fa-435c-b658-88020c14160e" />

#4: PATCH/UPDATE Sponsor Endpoint

Screenshot of Specific Sponsors Table Sponsor Row in Supabase Before Using Endpoint to Modify Its Data

<img width="1404" height="44" alt="image" src="https://github.com/user-attachments/assets/f955fe16-ac8a-409f-b82a-567acca3d4a8" />

Screenshots of Using the PATCH/UPDATE Sponsor Endpoint in Swagger Docs

<img width="1781" height="906" alt="image" src="https://github.com/user-attachments/assets/ff844a32-e0f9-4dde-8e61-8bb51a253fe7" />

<img width="1755" height="873" alt="image" src="https://github.com/user-attachments/assets/5855e638-0ae6-44b5-ab22-74c56b3a261e" />

<img width="1773" height="864" alt="image" src="https://github.com/user-attachments/assets/1e676b3c-e7e5-4179-add9-4a1619a0bd5c" />

Screenshot Showing How The "NVIDIA" Sponsor Row in the Sponsors Table Has Now Been Updated Based On The Specific Request Body(Seen In the Previous Image/Screenshot)

<img width="1526" height="47" alt="image" src="https://github.com/user-attachments/assets/47dff720-4ab9-4233-9a70-14cb61cd0ad2" />

#5: DELETE Sponsor Endpoint

Screenshot Showing Current Supabase Sponsors Table
<img width="1539" height="237" alt="image" src="https://github.com/user-attachments/assets/e69920b8-4e5f-476e-bd0c-a41a40f11ec3" />

We Are Specifically Going To Delete The "Google" Sponsor For This Example Test/Demo
<img width="1538" height="50" alt="image" src="https://github.com/user-attachments/assets/12d52f8c-27b3-4f91-b282-9e311b1d3c22" />

Screenshots of Using the DELETE Sponsor Endpoint in Swagger Docs

<img width="1828" height="420" alt="image" src="https://github.com/user-attachments/assets/f39c7b09-696d-431d-a1e4-bd1bcaa60673" />

<img width="1804" height="555" alt="image" src="https://github.com/user-attachments/assets/3be86b96-911d-473a-9eab-1d836865eb7e" />

<img width="1776" height="589" alt="image" src="https://github.com/user-attachments/assets/109d55f6-41b5-4f61-902f-3191e0f78d5f" />

Screenshot of Supabase Sponsors Table After Deleting the "Google" Sponsor(Shown In Previous Screenshot)

<img width="1534" height="177" alt="image" src="https://github.com/user-attachments/assets/2dcd5177-7627-4233-8d5f-54d055d43a65" />

As you can see from the screenshot, the sponsor row for "Google" has been deleted from the Sponsors table on Supabase.

## Testing Checklist
- [X] `npm run dev` runs without errors
- [X] Routes affected are verified
- [X] Mobile layout checked
- [X] No new console errors
- [X] Images load correctly (no 404s in Network tab)

## Reviewer Notes
N/A