### PR TITLE
Fixed Incorrect Email Address Link For "Contact Us" Button

### DIFF
--- a/src/components/GetInvolved/GetInvolved.jsx
+++ b/src/components/GetInvolved/GetInvolved.jsx
@@ -130,7 +130,7 @@ const GetInvolved = () => {
           <div className="cta-container fade-in-up">
             <h2>Ready to make an impact?</h2>
             <p>Reach out to us with any questions about getting involved.</p>
-            <a href="mailto:contact@blackintechatuci.com" className="cta-button">
+            <a href="mailto:blackintech@uci.edu" className="cta-button">
               <i className="far fa-envelope"></i> Contact Us
             </a>
           </div>


### PR DESCRIPTION
## Summary
This PR fixes the incorrect email address that's linked to the "Contact Us" button on the Get Involved page of the website, changing the email address from "contact@blackintechatuci.com" to "blackintech@uci.edu".

## Task Completion
Issue #36 

## Type of Change
- [X] Bug fix
-  [ ] Small UI fix
- [ ] Cleanup / refactor
- [ ] Docs update

## Routes / Pages Changed
-src/components/GetInvolved/GetInvolved.jsx

## Screenshots
Desktop:

Before Change/Fix:

<img width="765" height="315" alt="image" src="https://github.com/user-attachments/assets/968b5dd0-e7a4-4a3a-8976-c831874b391b" />

After Change/Fix:

<img width="775" height="260" alt="image" src="https://github.com/user-attachments/assets/892d875b-a3c2-4308-81bd-5afa51d84472" />


## Testing Checklist
- [X] `npm run dev` runs without errors
- [X] Routes affected are verified
- [X] Mobile layout checked
- [X] No new console errors
- [X] Images load correctly (no 404s in Network tab)

## Reviewer Notes
N/A