### PR TITLE
Centered Partners Section Text on About Us page.

### DIFF
--- a/src/components/ClubPageExample.css
+++ b/src/components/ClubPageExample.css
@@ -141,6 +141,15 @@
   flex: 1;
 }
 
+.partners-section .info-content {
+  justify-content: center;
+  text-align: center;
+}
+
+.partners-section .info-text {
+  max-width: 800px;
+}
+
 .info-text h2 {
   font-size: 2.5rem;
   color: #000 !important;


### PR DESCRIPTION
## Summary
This PR centers the paragraph text in the Partners section of the "About Us" page on the website.

## Task Completion
Issue #37 

## Type of Change
- [ ] Bug fix
- [X] Small UI fix
- [ ] Cleanup / refactor
- [ ] Docs update

## Routes / Pages Changed
- src/components/ClubPageExample.css

## Screenshots
Desktop:

Before Change/Fix:

<img width="678" height="162" alt="image" src="https://github.com/user-attachments/assets/499b18e0-9e36-479c-b88f-a51dfa14b51b" />

After Change/Fix:

<img width="777" height="241" alt="image" src="https://github.com/user-attachments/assets/3f521287-a1ba-4b3b-bc54-9d4ea1f53b47" />


Mobile (~390px): 

Before Change/Fix:

<img width="338" height="396" alt="image" src="https://github.com/user-attachments/assets/2d8b2967-6e20-417c-b8c4-e86dda6395a3" />

After Change/Fix:
<img width="361" height="416" alt="image" src="https://github.com/user-attachments/assets/e568fb15-cd2f-49f9-84ab-9f5143f1f3de" />

## Testing Checklist
- [X] `npm run dev` runs without errors
- [X] Routes affected are verified
- [X] Mobile layout checked
- [X] No new console errors
- [X] Images load correctly (no 404s in Network tab)

## Reviewer Notes
N/A